### PR TITLE
apply: Calls return a list of entities affected

### DIFF
--- a/src/lib/snowflake.ts
+++ b/src/lib/snowflake.ts
@@ -333,12 +333,27 @@ export async function showUsers(conn: Connection): Promise<ShowUser[]> {
   return (await sqlQuery<ShowUser[]>(conn, showUsersQuery, [])).results
 }
 
+// Deprecated. Use executeSqlCommands() instead.
 export async function executeCommands(conn: Connection, queries: Query[], dryRun = false): Promise<AppliedCommand[]> {
   let results: AppliedCommand[] = []
 
   for (const query of queries) {
     // eslint-disable-next-line no-await-in-loop
     const res = await sqlQuery(conn, query[0], query[1], {dryRun, dontReject: true})
+
+    results = [...results, res]
+  }
+
+  return results
+}
+
+export async function executeSqlCommands(conn: Connection, sqlCommands: SqlCommand[], dryRun = false): Promise<AppliedCommand[]> {
+  let results: AppliedCommand[] = []
+
+  for (const {query, entities} of sqlCommands) {
+    // eslint-disable-next-line no-await-in-loop
+    const res = await sqlQuery(conn, query[0], query[1], {dryRun, dontReject: true})
+    res.entities = entities
 
     results = [...results, res]
   }

--- a/src/lib/spyglass.ts
+++ b/src/lib/spyglass.ts
@@ -1,6 +1,6 @@
 import {Connection} from 'snowflake-sdk'
 import {findIssues, getIssueDetail, Issue, IssueDetail} from './issues'
-import {executeCommands, fqDatabaseId, fqObjectId, fqSchemaId, getConn, listGrantsToRolesFullScan, ShowObject, showObjects, ShowUser, showUsers, showWarehouses, sqlCommandsFromYamlDiff} from './snowflake'
+import {executeSqlCommands, fqDatabaseId, fqObjectId, fqSchemaId, getConn, listGrantsToRolesFullScan, ShowObject, showObjects, ShowUser, showUsers, showWarehouses, sqlCommandsFromYamlDiff} from './snowflake'
 import {compressYaml} from './snowflake-yaml-compress'
 import {AppliedCommand, Entity, SqlCommand} from './sql'
 import {diffYaml, Yaml, yamlFromRoleGrants, YamlRoleDefinitions} from './yaml'
@@ -129,9 +129,8 @@ export async function applySnowflake(currentYaml: Yaml, proposedYaml: Yaml, dryR
 
   // Convert differences to SQL commands.
   const sqlCommands = sqlCommandsFromYamlDiff(yamlDiff)
-  const sqlDiff = sqlCommands.map(x => x.query)
 
-  return executeCommands(conn, sqlDiff, dryRun)
+  return executeSqlCommands(conn, sqlCommands, dryRun)
 }
 
 export async function findNotExistingEntities(currentYaml: Yaml, proposedYaml: Yaml, conn?: Connection): Promise<Entity[]> {

--- a/src/lib/sql.ts
+++ b/src/lib/sql.ts
@@ -9,6 +9,7 @@ export interface AppliedCommand {
   results: any[];
   error?: string;
   errorCode?: number;
+  entities?: Entity[];
 }
 
 export interface QueryOptions {


### PR DESCRIPTION
The `AppliedCommand` interface now includes a list of `Entity` objects,
so library users can determine which entities (roles, user, objects) are
being changed.