### PR TITLE
Add support for database roles

### DIFF
--- a/src/lib/snowflake.ts
+++ b/src/lib/snowflake.ts
@@ -583,7 +583,7 @@ function getRolesQueries(roles: YamlRoleDefinitions | undefined, granted: boolea
   return queries
 }
 
-function getRoleGrantQueries(yamlRoles: YamlRoles, granted: boolean, database = false): SqlCommand[] {
+function getRoleGrantQueries(yamlRoles?: YamlRoles, granted?: boolean, database?: boolean): SqlCommand[] {
   if (!yamlRoles) return []
 
   const queries: SqlCommand[] = []
@@ -620,7 +620,7 @@ interface NewQueryBaseArgs {
   privilege: string;
   objectType: string;
   objectId: string;
-  database: boolean;
+  database?: boolean;
 }
 
 interface NewQueryArgs extends NewQueryBaseArgs {

--- a/src/lib/snowflake.ts
+++ b/src/lib/snowflake.ts
@@ -174,8 +174,6 @@ export async function listGrantsToRolesFullScan(conn: Connection, onStart: (x: n
   const [batchedRoleNames, numRoles] = await getBatchedRoleNames(showRoles)
   onStart(numRoles)
 
-  await sqlQuery(conn, 'alter session set multi_statement_count = 0;', []) // enable multi statement with batch size
-
   let roleGrants: ShowRoleGrant[] = []
   let futureRoleGrants: ShowFutureRoleGrant[] = []
   let roleGrantsOf: ShowRoleGrantOf[] = []

--- a/src/lib/spyglass.ts
+++ b/src/lib/spyglass.ts
@@ -14,8 +14,8 @@ export interface ImportArgs {
 
 export interface SyncArgs {
   yaml: Yaml;
-  onStart: (x: number) => void;
-  onProgress: (x: number) => void;
+  onStart: (total: number) => void;
+  onProgress: (current: number) => void;
 }
 
 export interface CheckArgs {
@@ -81,17 +81,10 @@ export async function importSnowflake({accountId, onStart, onProgress, compress}
   const roleGrantsPromise = listGrantsToRolesFullScan(conn, onStart, onProgress)
   const warehousesRowsPromise = showWarehouses(conn)
 
-  const [roleGrants, futureRoleGrants, roleGrantsOf, roles] = await roleGrantsPromise
+  const allGrants = await roleGrantsPromise
+  const warehouses = await warehousesRowsPromise
 
-  const grants = {
-    roleGrants,
-    futureRoleGrants,
-    roleGrantsOf,
-    roles,
-    warehouses: await warehousesRowsPromise,
-  }
-
-  const yaml = yamlFromRoleGrants(accountId, grants.roleGrants, grants.futureRoleGrants, grants.roleGrantsOf, grants.warehouses, grants.roles)
+  const yaml = yamlFromRoleGrants(accountId, allGrants, warehouses)
 
   if (compress) {
     yaml.spyglass.compressRecords = true

--- a/src/lib/spyglass.ts
+++ b/src/lib/spyglass.ts
@@ -153,7 +153,7 @@ export function _findNotExistingEntities(proposedRoles: YamlRoleDefinitions | un
 
   for (const entities of proposedEntities) {
     for (const entity of entities) {
-      if (entity.type === 'warehouse' || entity.type === 'database_role') {
+      if (entity.type === 'warehouse' || entity.type === 'database_role' || entity.type === 'database role') {
         continue // not supported yet
       }
 

--- a/src/lib/yaml.ts
+++ b/src/lib/yaml.ts
@@ -268,7 +268,6 @@ export interface YamlDiff {
   updated: Yaml;
 }
 
-// eslint-disable-next-line max-params
 export function yamlFromRoleGrants(accountId: string, allGrants: ListGrantsToRolesFullScanResult, warehouses: Warehouse[]): Yaml {
   const {roleGrants, futureRoleGrants, roleGrantsOf, roles, databaseRoles, databaseRoleGrants, databaseFutureRoleGrants, databaseRoleGrantsOf} = allGrants
 

--- a/src/lib/yaml.ts
+++ b/src/lib/yaml.ts
@@ -119,7 +119,7 @@ export interface Yaml {
    *
    * Updating this list will result in `database grant <privilege>` and `database revoke <privilege>` queries being executed.
    */
-  databaseRoleGrants: YamlRoles;
+  databaseRoleGrants?: YamlRoles;
 
   /** A list of warehouses and their configuration
    * @experimental
@@ -295,7 +295,7 @@ export function usersYamlFromUserGrants(rows: ShowRoleGrantOf[]): YamlUserGrants
   const userGrants: YamlUserGrants = {}
 
   for (const rg of rows) {
-    if (rg.granted_to !== 'USER') {
+    if (rg.granted_to.toLowerCase() !== 'user') {
       continue
     }
 

--- a/test/lib/snowflake.test.ts
+++ b/test/lib/snowflake.test.ts
@@ -70,12 +70,12 @@ describe('snowflake', () => {
   describe('query generation', () => {
     describe('basic grant', () => {
       it('generates grant', () => {
-        const cmd = snowflake.newGrantQuery('foo_usage', 'usage', 'schema', 'foo.bar')
+        const cmd = snowflake.newGrantQuery({roleName: 'foo_usage', privilege: 'usage', objectType: 'schema', objectId: 'foo.bar'})
         expect(cmd.query).to.deep.equal(['grant usage on schema identifier(?) to role identifier(?);', ['foo.bar', 'foo_usage']])
         expect(cmd.entities).to.deep.equal([{type: 'role', id: 'foo_usage', action: 'create'}, {type: 'schema', id: 'foo.bar', action: 'create'}])
       })
       it('generates revoke', () => {
-        const cmd = snowflake.newRevokeQuery('foo_usage', 'usage', 'schema', 'foo.bar')
+        const cmd = snowflake.newRevokeQuery({roleName: 'foo_usage', privilege: 'usage', objectType: 'schema', objectId: 'foo.bar'})
         expect(cmd.query).to.deep.equal(['revoke usage on schema identifier(?) from role identifier(?);', ['foo.bar', 'foo_usage']])
         expect(cmd.entities).to.deep.equal([{type: 'role', id: 'foo_usage', action: 'delete'}, {type: 'schema', id: 'foo.bar', action: 'delete'}])
       })
@@ -83,44 +83,44 @@ describe('snowflake', () => {
 
     describe('hierarchichal role grant', () => {
       it('generates grant', () => {
-        const cmd = snowflake.newGrantQuery('foo_usage', 'usage', 'role', 'bar_usage')
+        const cmd = snowflake.newGrantQuery({roleName: 'foo_usage', privilege: 'usage', objectType: 'role', objectId: 'bar_usage'})
         expect(cmd.query).to.deep.equal(['grant role identifier(?) to role identifier(?);', ['bar_usage', 'foo_usage']])
       })
       it('generates revoke', () => {
-        const cmd = snowflake.newRevokeQuery('foo_usage', 'usage', 'role', 'bar_usage')
+        const cmd = snowflake.newRevokeQuery({roleName: 'foo_usage', privilege: 'usage', objectType: 'role', objectId: 'bar_usage'})
         expect(cmd.query).to.deep.equal(['revoke role identifier(?) from role identifier(?);', ['bar_usage', 'foo_usage']])
       })
     })
 
     describe('schema future grants', () => {
       it('generates grant', () => {
-        const cmd = snowflake.newGrantQuery('foo_bar_viewer', 'insert', 'table', 'foo.bar.<table>')
+        const cmd = snowflake.newGrantQuery({roleName: 'foo_bar_viewer', privilege: 'insert', objectType: 'table', objectId: 'foo.bar.<table>'})
         expect(cmd.query).to.deep.equal(['grant insert on future tables in schema identifier(?) to role identifier(?);', ['foo.bar', 'foo_bar_viewer']])
       })
       it('generates revoke', () => {
-        const cmd = snowflake.newRevokeQuery('foo_bar_viewer', 'insert', 'table', 'foo.bar.<future>')
+        const cmd = snowflake.newRevokeQuery({roleName: 'foo_bar_viewer', privilege: 'insert', objectType: 'table', objectId: 'foo.bar.<table>'})
         expect(cmd.query).to.deep.equal(['revoke insert on future tables in schema identifier(?) from role identifier(?);', ['foo.bar', 'foo_bar_viewer']])
       })
     })
 
     describe('database future grants on tables', () => {
       it('generates grant', () => {
-        const cmd = snowflake.newGrantQuery('foo_viewer', 'insert', 'table', 'foo.<table>')
+        const cmd = snowflake.newGrantQuery({roleName: 'foo_viewer', privilege: 'insert', objectType: 'table', objectId: 'foo.<table>'})
         expect(cmd.query).to.deep.equal(['grant insert on future tables in database identifier(?) to role identifier(?);', ['foo', 'foo_viewer']])
       })
       it('generates revoke', () => {
-        const cmd = snowflake.newRevokeQuery('foo_viewer', 'usage', 'schema', 'foo.<schema>')
+        const cmd = snowflake.newRevokeQuery({roleName: 'foo_viewer', privilege: 'usage', objectType: 'schema', objectId: 'foo.<schema>'})
         expect(cmd.query).to.deep.equal(['revoke usage on future schemas in database identifier(?) from role identifier(?);', ['foo', 'foo_viewer']])
       })
     })
 
     describe('all tables in schema / database', () => {
       it('generates grant on all in schema', () => {
-        const cmd = snowflake.newGrantQuery('foo_bar_viewer', 'select', 'table', 'foo.bar.*')
+        const cmd = snowflake.newGrantQuery({roleName: 'foo_bar_viewer', privilege: 'select', objectType: 'table', objectId: 'foo.bar.*'})
         expect(cmd.query).to.deep.equal(['grant select on all tables in schema identifier(?) to role identifier(?);', ['foo.bar', 'foo_bar_viewer']])
       })
       it('generates revoke on all in database', () => {
-        const cmd = snowflake.newRevokeQuery('foo_viewer', 'select', 'table', 'foo.*')
+        const cmd = snowflake.newRevokeQuery({roleName: 'foo_viewer', privilege: 'select', objectType: 'table', objectId: 'foo.*'})
         expect(cmd.query).to.deep.equal(['revoke select on all tables in database identifier(?) from role identifier(?);', ['foo', 'foo_viewer']])
       })
     })

--- a/test/testdata/spyglass-import-snowflake-stub-basic.json
+++ b/test/testdata/spyglass-import-snowflake-stub-basic.json
@@ -1,99 +1,103 @@
-[
-  [
+{
+  "roleGrants": [
     {
       "created_on": "2023-02-26 12:40:02.747 -0800",
-      "privilege": "SELECT",
-      "granted_on": "VIEW",
-      "name": "ACME.PROD.CALL_CENTER",
-      "granted_to": "ROLE",
-      "grantee_name": "ACME_PROD_CALL_CENTER_READER",
+      "privilege": "select",
+      "granted_on": "view",
+      "name": "acme.prod.call_center",
+      "granted_to": "role",
+      "grantee_name": "acme_prod_call_center_reader",
       "grant_option": "false",
-      "granted_by": "ACCOUNTADMIN"
+      "granted_by": "accountadmin"
     },
     {
       "created_on": "2023-02-26 12:40:02.747 -0800",
-      "privilege": "USAGE",
-      "granted_on": "DATABASE",
-      "name": "ACME",
-      "granted_to": "ROLE",
-      "grantee_name": "ACME_PROD_CALL_CENTER_READER",
+      "privilege": "usage",
+      "granted_on": "database",
+      "name": "acme",
+      "granted_to": "role",
+      "grantee_name": "acme_prod_call_center_reader",
       "grant_option": "false",
-      "granted_by": "ACCOUNTADMIN"
+      "granted_by": "accountadmin"
     },
     {
       "created_on": "2023-02-26 12:40:02.747 -0800",
-      "privilege": "USAGE",
-      "granted_on": "SCHEMA",
-      "name": "ACME.PROD",
-      "granted_to": "ROLE",
-      "grantee_name": "ACME_PROD_CALL_CENTER_READER",
+      "privilege": "usage",
+      "granted_on": "schema",
+      "name": "acme.prod",
+      "granted_to": "role",
+      "grantee_name": "acme_prod_call_center_reader",
       "grant_option": "false",
-      "granted_by": "ACCOUNTADMIN"
+      "granted_by": "accountadmin"
     },
     {
       "created_on": "2023-02-26 12:40:02.747 -0800",
-      "privilege": "USAGE",
-      "granted_on": "ROLE",
-      "name": "ACME_PROD_CALL_CENTER_READER",
-      "granted_to": "ROLE",
-      "grantee_name": "CUSTOMER_SUPPORT",
+      "privilege": "usage",
+      "granted_on": "role",
+      "name": "acme_prod_call_center_reader",
+      "granted_to": "role",
+      "grantee_name": "customer_support",
       "grant_option": "false",
-      "granted_by": "ACCOUNTADMIN"
+      "granted_by": "accountadmin"
     }
   ],
-  [
+  "futureRoleGrants": [
     {
       "created_on": "2023-03-10 06:29:45.905 -0800",
-      "privilege": "SELECT",
-      "grant_on": "TABLE",
-      "name": "ACME.PROD.<TABLE>",
-      "grant_to": "ROLE",
-      "grantee_name": "ACME_PROD_ALL_TABLES_VIEWER",
+      "privilege": "select",
+      "grant_on": "table",
+      "name": "acme.prod.<table>",
+      "grant_to": "role",
+      "grantee_name": "acme_prod_all_tables_viewer",
       "grant_option": "false"
     }
   ],
-  [
+  "roleGrantsOf": [
     {
       "created_on": "2023-02-26 12:49:23.439 -0800",
-      "role": "ACME_PROD_CALL_CENTER_READER",
-      "granted_to": "ROLE",
-      "grantee_name": "CUSTOMER_SUPPORT",
-      "granted_by": "ACCOUNTADMIN"
+      "role": "acme_prod_call_center_reader",
+      "granted_to": "role",
+      "grantee_name": "customer_support",
+      "granted_by": "accountadmin"
     },
     {
       "created_on": "2023-02-26 12:49:41.301 -0800",
-      "role": "CUSTOMER_SUPPORT",
-      "granted_to": "USER",
-      "grantee_name": "CHUCK_SUPPORT",
-      "granted_by": "ACCOUNTADMIN"
+      "role": "customer_support",
+      "granted_to": "user",
+      "grantee_name": "chuck_support",
+      "granted_by": "accountadmin"
     },
     {
       "created_on": "2023-02-26 12:49:41.301 -0800",
-      "role": "ACME_PROD_ALL_TABLES_VIEWER",
-      "granted_to": "USER",
-      "grantee_name": "ALICE_ADMIN",
-      "granted_by": "ACCOUNTADMIN"
+      "role": "acme_prod_all_tables_viewer",
+      "granted_to": "user",
+      "grantee_name": "alice_admin",
+      "granted_by": "accountadmin"
     },
     {
       "created_on": "2023-02-26 12:49:41.301 -0800",
-      "role": "Snowflake - Admins",
-      "granted_to": "USER",
-      "grantee_name": "ALICE_ADMIN",
-      "granted_by": "ACCOUNTADMIN"
+      "role": "\"Snowflake - Admins\"",
+      "granted_to": "user",
+      "grantee_name": "alice_admin",
+      "granted_by": "accountadmin"
     }
   ],
-  [
+  "roles": [
     {
-      "name": "ACME_PROD_CALL_CENTER_READER"
+      "name": "acme_prod_call_center_reader"
     },
     {
-      "name": "CUSTOMER_SUPPORT"
+      "name": "customer_support"
     },
     {
-      "name": "ACME_PROD_ALL_TABLES_VIEWER"
+      "name": "acme_prod_all_tables_viewer"
     },
     {
-      "name": "Snowflake - Admins"
+      "name": "\"Snowflake - Admins\""
     }
-  ]
-]
+  ],
+  "databaseRoles": [],
+  "databaseFutureRoleGrants": [],
+  "databaseRoleGrants": [],
+  "databaseRoleGrantsOf": []
+}

--- a/test/testdata/spyglass-sync-snowflake-stub-basic.json
+++ b/test/testdata/spyglass-sync-snowflake-stub-basic.json
@@ -1,28 +1,32 @@
-[
-  [],
-  [
+{
+  "roleGrants": [],
+  "futureRoleGrants": [
     {
       "created_on": "2023-03-10 06:29:45.905 -0800",
-      "privilege": "SELECT",
-      "grant_on": "TABLE",
-      "name": "ACME.PROD.<TABLE>",
-      "grant_to": "ROLE",
-      "grantee_name": "ACME_PROD_ALL_TABLES_VIEWER",
+      "privilege": "select",
+      "grant_on": "table",
+      "name": "acme.prod.<table>",
+      "grant_to": "role",
+      "grantee_name": "acme_prod_all_tables_viewer",
       "grant_option": "false"
     }
   ],
-  [
+  "roleGrantsOf": [
     {
       "created_on": "2023-02-26 12:49:41.301 -0800",
-      "role": "ACME_PROD_ALL_TABLES_VIEWER",
-      "granted_to": "USER",
-      "grantee_name": "ALICE_ADMIN",
-      "granted_by": "ACCOUNTADMIN"
+      "role": "acme_prod_all_tables_viewer",
+      "granted_to": "user",
+      "grantee_name": "alice_admin",
+      "granted_by": "accountadmin"
     }
   ],
-  [
+  "roles": [
     {
-      "name": "ACME_PROD_ALL_TABLES_VIEWER"
+      "name": "acme_prod_all_tables_viewer"
     }
-  ]
-]
+  ],
+  "databaseRoles": [],
+  "databaseFutureRoleGrants": [],
+  "databaseRoleGrants": [],
+  "databaseRoleGrantsOf": []
+}


### PR DESCRIPTION
Spyglass `import`, `sync`, and `apply` now support database roles, including all commands:

```
create database role;
drop database role;
grant [...] to database role;
revoke [...] from database role;
```