### PR TITLE
apply: run apply commands in parallel with a rate limit

### DIFF
--- a/src/lib/ratelimit.ts
+++ b/src/lib/ratelimit.ts
@@ -1,3 +1,6 @@
+
+export type SetInterval = (callback: (args: void) => void, ms?: number) => NodeJS.Timer
+
 export class RateLimiter {
   private rps: number
   private interval: NodeJS.Timer
@@ -6,16 +9,21 @@ export class RateLimiter {
 
   private resolvers: ((value: void | PromiseLike<void>) => void)[]
 
-  constructor(rps: number) {
+  constructor(rps: number, _setInterval: SetInterval = setInterval) {
     this.closed = false
     this.rps = rps
     this.resolvers = []
 
     const sliceFactor = 5 // Arbitrarily update the count every 5th of a second, slightly more smooth than every 1 second.
-    this.interval = setInterval(() => {
+    this.interval = _setInterval(() => {
       if (this.resolvers.length === 0) {
         return
       }
+
+      // NOTE: Technically, this implementation works best when all the requests are queued up in a large batch,
+      // and isn't quite correct if requests stream in over time. This is because every 5th of a second, we are pulling
+      // 2 requests off of the request queue. So if there aren't any requests in this time chunk, we won't try to "catch up"
+      // on the next tick. This is acceptable given our usage.
 
       const numCalls = Math.floor(this.rps / sliceFactor)
       for (let i = 0; i < numCalls; i++) {
@@ -41,34 +49,52 @@ export class RateLimiter {
     })
   }
 
-  async close(): Promise<void> {
+  close(): void {
     clearInterval(this.interval)
   }
 }
 
 export class WaitGroup {
   private count: number
+  private interval?: NodeJS.Timer
+  private closed: boolean
 
   constructor() {
     this.count = 0
+    this.closed = false
   }
 
-  add(): void {
-    this.count += 1
+  add(n = 1): void {
+    if (this.closed) {
+      throw new Error('wait group is closed')
+    }
+
+    const newCount = this.count + n
+
+    if (newCount < 0) {
+      throw new Error('negative wait group counter')
+    }
+
+    this.count = newCount
   }
 
   done(): void {
-    this.count -= 1
+    this.add(-1)
   }
 
   async wait(): Promise<void> {
     return new Promise(resolve => {
-      const interval = setInterval(() => {
+      this.interval = setInterval(() => {
         if (this.count === 0) {
-          clearInterval(interval)
+          this.close()
           resolve()
         }
-      }, 1000)
+      }, 100)
     })
+  }
+
+  close(): void {
+    this.closed = true
+    clearInterval(this.interval)
   }
 }

--- a/src/lib/ratelimit.ts
+++ b/src/lib/ratelimit.ts
@@ -1,0 +1,74 @@
+export class RateLimiter {
+  private rps: number
+  private interval: NodeJS.Timer
+  private SECOND_MS = 1000
+  private closed: boolean
+
+  private resolvers: ((value: void | PromiseLike<void>) => void)[]
+
+  constructor(rps: number) {
+    this.closed = false
+    this.rps = rps
+    this.resolvers = []
+
+    const sliceFactor = 5 // Arbitrarily update the count every 5th of a second, slightly more smooth than every 1 second.
+    this.interval = setInterval(() => {
+      if (this.resolvers.length === 0) {
+        return
+      }
+
+      const numCalls = Math.floor(this.rps / sliceFactor)
+      for (let i = 0; i < numCalls; i++) {
+        const resolve = this.resolvers.pop()
+        if (resolve) {
+          resolve()
+        }
+      }
+    }, this.SECOND_MS / sliceFactor)
+  }
+
+  async wait(): Promise<void> {
+    if (this.closed) {
+      throw new Error('rate limiter attempted to wait after it was closed')
+    }
+
+    if (this.rps === 0) {
+      return
+    }
+
+    return new Promise(resolve => {
+      this.resolvers.push(resolve)
+    })
+  }
+
+  async close(): Promise<void> {
+    clearInterval(this.interval)
+  }
+}
+
+export class WaitGroup {
+  private count: number
+
+  constructor() {
+    this.count = 0
+  }
+
+  add(): void {
+    this.count += 1
+  }
+
+  done(): void {
+    this.count -= 1
+  }
+
+  async wait(): Promise<void> {
+    return new Promise(resolve => {
+      const interval = setInterval(() => {
+        if (this.count === 0) {
+          clearInterval(interval)
+          resolve()
+        }
+      }, 1000)
+    })
+  }
+}

--- a/test/lib/ratelimit.test.ts
+++ b/test/lib/ratelimit.test.ts
@@ -1,0 +1,114 @@
+import * as ratelimit from '../../src/lib/ratelimit'
+import {expect} from 'chai'
+
+describe('ratelimit', () => {
+  describe('WaitGroup', () => {
+    it('waits until all work is done', async () => {
+      const wg = new ratelimit.WaitGroup()
+
+      for (let i = 0; i < 100_000; i++) {
+        wg.add()
+
+        setTimeout(() => {
+          wg.done()
+        }, 10)
+      }
+
+      await wg.wait()
+    })
+
+    it('wait hangs if not all work is completed', done => {
+      const wg = new ratelimit.WaitGroup()
+
+      wg.add()
+      wg.add()
+      wg.add()
+
+      setTimeout(() => {
+        wg.done()
+      }, 10)
+
+      setTimeout(() => {
+        wg.done()
+      }, 10)
+
+      setTimeout(() => {
+        // if after 1 second, wait() hasn't resolved, we're good
+        wg.close()
+        done()
+      }, 1000)
+
+      wg.wait().then(() => {
+        expect.fail('wait() should not resolve')
+      })
+    })
+
+    it('throws error if used after close', async () => {
+      const wg = new ratelimit.WaitGroup()
+      wg.add()
+      wg.done()
+      await wg.wait()
+
+      expect(() => wg.add()).to.throw('wait group is closed')
+      expect(() => wg.done()).to.throw('wait group is closed')
+    })
+
+    it('throws error if count is negative', async () => {
+      const wg = new ratelimit.WaitGroup()
+      wg.add()
+      wg.done()
+      expect(() => wg.done()).to.throw('negative wait group counter')
+    })
+  })
+
+  describe('RateLimiter', () => {
+    it('success', done => {
+      // eslint-disable-next-line @typescript-eslint/no-empty-function, unicorn/consistent-function-scoping
+      let mockCallback = (_args: void): void => {}
+
+      const mockSetInterval = (callback: (args: void) => void, _ms?: number): NodeJS.Timer => {
+        mockCallback = callback
+        return setInterval(() => null, 1000) // no-op to satisfy the function signature
+      }
+
+      const wg = new ratelimit.WaitGroup()
+
+      const limit = 10
+      const rl = new ratelimit.RateLimiter(limit, mockSetInterval)
+
+      for (let i = 0; i < limit; i++) {
+        rl.wait()
+      }
+
+      let unblocked = false
+      wg.add()
+
+      setTimeout(async () => {
+        // this should block until the second setTimeout gets called that invokes the mockCallback
+        await rl.wait()
+        expect(unblocked).to.be.true
+        wg.done()
+      }, 1)
+
+      setTimeout(() => {
+        unblocked = true
+        mockCallback()
+      }, 100)
+
+      wg.wait().then(() => {
+        rl.close()
+        done()
+      })
+    })
+
+    it('disabled rate limiter', async () => {
+      const rl = new ratelimit.RateLimiter(0)
+      for (let i = 0; i < 100_000; i++) {
+        // eslint-disable-next-line no-await-in-loop
+        await rl.wait()
+      }
+
+      rl.close()
+    })
+  })
+})


### PR DESCRIPTION
After this change, when `apply` runs, it will execute commands in parallel, rather
than synchronously. Because of this, we need to add rate limiting to ensure we
don't overload the database.