### PR TITLE
import/sync no longer forces all names to lower case

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -1,4 +1,4 @@
-import {Args, Flags, ux} from '@oclif/core'
+import {Args, ux} from '@oclif/core'
 import {BaseCommand} from '../lib/cmd'
 import color from '@oclif/color'
 import {Config, getConfig} from '../lib/config'
@@ -12,9 +12,7 @@ export default class Import extends BaseCommand {
     accountId: Args.string({description: 'Account id to fetch configuration from.', required: true, parse: async a => a.toLowerCase()}),
   }
 
-  static flags = {
-    compress: Flags.boolean({description: 'Whether to compress records and replace them with a wildcard (*) where applicable.', default: false}),
-  }
+  static flags = {}
 
   async run(): Promise<void> {
     await this.init()
@@ -63,7 +61,6 @@ export default class Import extends BaseCommand {
       accountId,
       onStart: total => progress.start(total, 0),
       onProgress: current => progress.update(current),
-      compress: true,
     })
 
     progress.stop()

--- a/src/lib/obj-merge.ts
+++ b/src/lib/obj-merge.ts
@@ -19,3 +19,35 @@ export function mergeDeep(target: Record<string, any>, ...sources: Record<string
 
   return mergeDeep(target, ...sources)
 }
+
+export function mergeDeepAndCombineLists(
+  target: Record<string, any>,
+  ...sources: Record<string, any>[]
+): Record<string, any> {
+  if (sources.length === 0) return target
+  const source = sources.shift()
+
+  if (!source) {
+    return target
+  }
+
+  if (isObject(target) && isObject(source)) {
+    for (const key of Object.keys(source)) {
+      if (isObject(source[key])) {
+        if (!target[key]) Object.assign(target, {[key]: {}})
+        mergeDeepAndCombineLists(target[key], source[key])
+      } else if (Array.isArray(source[key])) {
+        if (!target[key]) target[key] = source[key]
+        target[key] = combineLists(target[key], source[key])
+      } else {
+        Object.assign(target, {[key]: source[key]})
+      }
+    }
+  }
+
+  return mergeDeepAndCombineLists(target, ...sources)
+}
+
+function combineLists(a: any[], b: any[]) {
+  return [...new Set([...a, ...b])].sort()
+}

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -29,13 +29,13 @@ export function userAccessFromYaml(yaml: Yaml, username: string): UserAccess {
 
     // TYLER: check for infinite loop in yaml
 
-    const inheritedRoleNames = yaml.roleGrants?.[role.name]?.usage?.role ?? []
+    const inheritedRoleNames = yaml.roleGrants?.[role.name]?.USAGE?.role ?? []
     const inheritedRoles = inheritedRoleNames.map(name => ({name, parents: [...role.parents, role.name]}))
     rolesToDescend = [...rolesToDescend, ...inheritedRoles]
 
     for (const [privilege, objectLists] of Object.entries(yaml.roleGrants?.[role.name] ?? {})) {
-      for (const [objectType, objectIds] of Object.entries(objectLists)) {
-        if (privilege === 'usage' && objectType === 'role') {
+      for (const [objectType, objectIds] of Object.entries(objectLists ?? {})) {
+        if (privilege === 'USAGE' && objectType === 'ROLE') {
           continue
         }
 
@@ -77,7 +77,7 @@ export function userRolesFromYaml(yaml: Yaml, username: string): UserRoles {
 
     // TYLER: check for infinite loop in yaml
 
-    const inheritedRoleNames = yaml.roleGrants?.[role.name]?.usage?.role ?? []
+    const inheritedRoleNames = yaml.roleGrants?.[role.name]?.USAGE?.role ?? []
     const inheritedRoles = inheritedRoleNames.map(name => ({name, parents: [...role.parents, role.name]}))
     rolesToDescend = [...rolesToDescend, ...inheritedRoles]
 
@@ -112,13 +112,13 @@ export function objectAccessFromYaml(yaml: Yaml, targetObjectId: string): Object
 
     // TYLER: check for infinite loop in yaml
 
-    const inheritedRoleNames = yaml.roleGrants?.[role.name]?.usage?.role ?? []
+    const inheritedRoleNames = yaml.roleGrants?.[role.name]?.USAGE?.role ?? []
     const inheritedRoles = inheritedRoleNames.map(name => ({name, parents: [...role.parents, role.name]}))
     rolesToDescend = [...rolesToDescend, ...inheritedRoles]
 
     for (const [privilege, objectLists] of Object.entries(yaml.roleGrants?.[role.name] ?? {})) {
-      for (const [objectType, objectIds] of Object.entries(objectLists)) {
-        if (privilege === 'usage' && objectType === 'role') {
+      for (const [objectType, objectIds] of Object.entries(objectLists ?? {})) {
+        if (privilege === 'USAGE' && objectType === 'ROLE') {
           continue
         }
 

--- a/src/lib/spyglass.ts
+++ b/src/lib/spyglass.ts
@@ -98,7 +98,7 @@ export async function verifySnowflake(yaml: Yaml, issueId?: string): Promise<Iss
 export async function syncSnowflake(args: SyncArgs, conn?: Connection): Promise<Yaml> {
   const latestYaml = await importSnowflake({accountId: args.yaml.spyglass.accountId, ...args}, conn)
 
-  latestYaml.spyglass = args.yaml.spyglass
+  latestYaml.spyglass = structuredClone(args.yaml.spyglass)
   latestYaml.spyglass.lastSyncedMs = Date.now()
 
   return latestYaml

--- a/src/lib/spyglass.ts
+++ b/src/lib/spyglass.ts
@@ -1,7 +1,6 @@
 import {Connection} from 'snowflake-sdk'
 import {findIssues, getIssueDetail, Issue, IssueDetail} from './issues'
 import {executeSqlCommands, fqDatabaseId, fqObjectId, fqSchemaId, getConn, listGrantsToRolesFullScan, ShowObject, showObjects, ShowUser, showUsers, showWarehouses, sqlCommandsFromYamlDiff} from './snowflake'
-import {compressYaml} from './snowflake-yaml-compress'
 import {AppliedCommand, Entity, SqlCommand} from './sql'
 import {diffYaml, Yaml, yamlFromRoleGrants, YamlRoleDefinitions} from './yaml'
 
@@ -9,7 +8,6 @@ export interface ImportArgs {
   accountId: string;
   onStart: (x: number) => void;
   onProgress: (x: number) => void;
-  compress?: boolean;
 }
 
 export interface SyncArgs {
@@ -73,7 +71,7 @@ export class SnowflakeSpyglass implements Spyglass {
   }
 }
 
-export async function importSnowflake({accountId, onStart, onProgress, compress}: ImportArgs, conn?: Connection): Promise<Yaml> {
+export async function importSnowflake({accountId, onStart, onProgress}: ImportArgs, conn?: Connection): Promise<Yaml> {
   if (!conn) {
     conn = await getConn(accountId)
   }
@@ -85,12 +83,6 @@ export async function importSnowflake({accountId, onStart, onProgress, compress}
   const warehouses = await warehousesRowsPromise
 
   const yaml = yamlFromRoleGrants(accountId, allGrants, warehouses)
-
-  if (compress) {
-    yaml.spyglass.compressRecords = true
-    const objects = await showObjects(conn)
-    compressYaml(yaml, objects)
-  }
 
   return yaml
 }
@@ -104,7 +96,7 @@ export async function verifySnowflake(yaml: Yaml, issueId?: string): Promise<Iss
 }
 
 export async function syncSnowflake(args: SyncArgs, conn?: Connection): Promise<Yaml> {
-  const latestYaml = await importSnowflake({accountId: args.yaml.spyglass.accountId, compress: args.yaml.spyglass?.compressRecords, ...args}, conn)
+  const latestYaml = await importSnowflake({accountId: args.yaml.spyglass.accountId, ...args}, conn)
 
   latestYaml.spyglass = args.yaml.spyglass
   latestYaml.spyglass.lastSyncedMs = Date.now()
@@ -151,15 +143,15 @@ export async function findNotExistingEntities(currentYaml: Yaml, proposedYaml: Y
   return _findNotExistingEntities(proposedYaml.roles, objects, users, sqlCommands)
 }
 
-const supportedNonExistingEntities = new Set(['database', 'schema', 'user', 'role', 'table', 'view'])
+const supportedNonExistingEntities = new Set(['DATABASE', 'SCHEMA', 'USER', 'ROLE', 'TABLE', 'VIEW'])
 
 export function _findNotExistingEntities(proposedRoles: YamlRoleDefinitions | undefined, objects: ShowObject[], users: ShowUser[], sqlCommands: SqlCommand[]): Entity[] {
   let res: Entity[] = []
 
-  const existingRoles = Object.keys(proposedRoles ?? {}).map(roleName => `role:${roleName}`)
-  const existingObjects = objects.map(o => `${o.kind.toLowerCase()}:${fqObjectId(o.database_name, o.schema_name, o.name)}`)
+  const existingRoles = Object.keys(proposedRoles ?? {}).map(roleName => `ROLE:${roleName}`)
+  const existingObjects = objects.map(o => `${o.kind}:${fqObjectId(o.database_name, o.schema_name, o.name)}`)
   const existingAccountObjects = getDatabasesAndSchemas(objects)
-  const existingUsers = users.map(u => `user:${u.name.toLowerCase()}`)
+  const existingUsers = users.map(u => `USER:${u.name}`)
   const existingEntities = new Set([...existingRoles, ...existingObjects, ...existingAccountObjects, ...existingUsers])
 
   const proposedEntities = sqlCommands.map(x => x.entities)
@@ -189,8 +181,8 @@ function getDatabasesAndSchemas(objects: ShowObject[]): string[] {
   const res: Set<string> = new Set()
 
   for (const obj of objects) {
-    res.add(`database:${fqDatabaseId(obj.database_name)}`)
-    res.add(`schema:${fqSchemaId(obj.database_name, obj.schema_name)}`)
+    res.add(`DATABASE:${fqDatabaseId(obj.database_name)}`)
+    res.add(`SCHEMA:${fqSchemaId(obj.database_name, obj.schema_name)}`)
   }
 
   return [...res]

--- a/src/lib/yaml-util.ts
+++ b/src/lib/yaml-util.ts
@@ -11,7 +11,7 @@ interface ObjectIdIter {
 export function forEachObjectInRoleGrants(roleGrants: YamlRoles, fn: (_: ObjectIdIter) => void): void {
   for (const [roleName, roleInfo] of Object.entries(roleGrants)) {
     for (const [privilege, objectLists] of Object.entries(roleInfo)) {
-      for (const [objectType, objectIds] of Object.entries(objectLists)) {
+      for (const [objectType, objectIds] of Object.entries(objectLists ?? {})) {
         for (const objectId of objectIds) {
           fn({
             roleName,

--- a/src/lib/yaml.ts
+++ b/src/lib/yaml.ts
@@ -13,9 +13,9 @@ roleGrants:
   acme_prod_all_tables_viewer:
     select:
       table:
-        - acme.prod.<future>
+        - acme.prod.<FUTURE>
       view:
-        - acme.prod.<future>
+        - acme.prod.<FUTURE>
         - acme.prod.call_center
         - acme.prod.catalog_page
         - acme.prod.catalog_returns
@@ -38,8 +38,8 @@ userGrants:
  *
  * ### Special Operators
  *
- * As seen above, you can use `database.schema.<future>` to create a "future grants" statement,
- * such as `acme.prod.<future>` to grant access to all future views.
+ * As seen above, you can use `database.schema.<FUTURE>` to create a "future grants" statement,
+ * such as `acme.prod.<FUTURE>` to grant access to all future views.
  *
  * Additionally, you can use `database.schema.*` to create an "all grants" statement, such as
  * `acme.prod.*` to grant access to all current views.
@@ -58,10 +58,89 @@ import {detailedDiff} from 'deep-object-diff'
 import {deeplyConvertSetsToStringLists, deeplyConvertStringListsToSets, deeplySortLists, replaceUndefinedValuesWithDeletedValues} from './difftools'
 import {ListGrantsToRolesFullScanResult, ShowDatabaseRole, ShowFutureRoleGrant, ShowRole, ShowRoleGrant, ShowRoleGrantOf, Warehouse} from './snowflake'
 
-export const PRIVILEGES = ['apply', 'apply masking policy', 'apply row access policy', 'apply tag', 'audit', 'create account', 'create credential', 'create data exchange listing', 'create failover group', 'create integration', 'create replication group', 'create role', 'create share', 'create stage', 'execute alert', 'execute managed task', 'execute task', 'import share', 'manage account support cases', 'manage user support cases', 'monitor', 'monitor execution', 'monitor security', 'monitor usage', 'override share restrictions', 'ownership', 'purchase data exchange listing', 'reference_usage', 'select', 'usage', 'insert', 'update', 'delete', 'truncate', 'references', 'read', 'write', 'operate', 'create database role'] as const
+export const PRIVILEGES = [
+  'all privileges',
+  'apply',
+  'apply masking policy',
+  'apply row access policy',
+  'apply tag',
+  'audit',
+  'create account',
+  'create credential',
+  'create data exchange listing',
+  'create failover group',
+  'create integration',
+  'create replication group',
+  'create role',
+  'create share',
+  'execute alert',
+  'execute managed task',
+  'execute task',
+  'import share',
+  'manage account support cases',
+  'manage user support cases',
+  'monitor',
+  'monitor execution',
+  'monitor security',
+  'monitor usage',
+  'override share restrictions',
+  'ownership',
+  'purchase data exchange listing',
+  'reference_usage',
+  'select',
+  'usage',
+  'insert',
+  'update',
+  'delete',
+  'truncate',
+  'references',
+  'read',
+  'write',
+  'operate',
+  'create database role',
+  'ALL PRIVILEGES',
+  'APPLY',
+  'APPLY MASKING POLICY',
+  'APPLY ROW ACCESS POLICY',
+  'APPLY TAG',
+  'AUDIT',
+  'CREATE ACCOUNT',
+  'CREATE CREDENTIAL',
+  'CREATE DATA EXCHANGE LISTING',
+  'CREATE FAILOVER GROUP',
+  'CREATE INTEGRATION',
+  'CREATE REPLICATION GROUP',
+  'CREATE ROLE',
+  'CREATE SHARE',
+  'EXECUTE ALERT',
+  'EXECUTE MANAGED TASK',
+  'EXECUTE TASK',
+  'IMPORT SHARE',
+  'MANAGE ACCOUNT SUPPORT CASES',
+  'MANAGE USER SUPPORT CASES',
+  'MONITOR',
+  'MONITOR EXECUTION',
+  'MONITOR SECURITY',
+  'MONITOR USAGE',
+  'OVERRIDE SHARE RESTRICTIONS',
+  'OWNERSHIP',
+  'PURCHASE DATA EXCHANGE LISTING',
+  'REFERENCE_USAGE',
+  'SELECT',
+  'USAGE',
+  'INSERT',
+  'UPDATE',
+  'DELETE',
+  'TRUNCATE',
+  'REFERENCES',
+  'READ',
+  'WRITE',
+  'OPERATE',
+  'CREATE DATABASE ROLE',
+]
 export type Privilege = typeof PRIVILEGES[number]
 
-const EXCLUDED_ROLES = new Set(['accountadmin', 'securityadmin', 'useradmin', 'orgadmin', 'pc_spyglass_role'])
+const EXCLUDED_ROLES = new Set(['ACCOUNTADMIN', 'SECURITYADMIN', 'USERADMIN', 'ORGADMIN'])
 
 export type Platform = 'snowflake' | 'unspecified';
 
@@ -295,7 +374,7 @@ export function usersYamlFromUserGrants(rows: ShowRoleGrantOf[]): YamlUserGrants
   const userGrants: YamlUserGrants = {}
 
   for (const rg of rows) {
-    if (rg.granted_to.toLowerCase() !== 'user') {
+    if (rg.granted_to !== 'USER') {
       continue
     }
 
@@ -353,7 +432,7 @@ export function rolesYamlFromRoleGrants(rows: ShowRoleGrant[], futureRoleGrants:
       name: _name,
     } = rg
     const privilege = _privilege as Privilege
-    const name = _name.replace(/<.*>/, '<future>')
+    const name = _name.replace(/<.*>/, '<FUTURE>')
 
     const role = roleGrants[grantee] ?? {}
     roleGrants[grantee] = role

--- a/test/lib/issues.test.ts
+++ b/test/lib/issues.test.ts
@@ -5,7 +5,7 @@ import * as chaiAsPromised from 'chai-as-promised'
 
 use(chaiAsPromised)
 
-describe('difftools', () => {
+describe('issues', () => {
   describe('findIssues', async () => {
     it('finds many issues', async () => {
       const yaml = await readYamlFile('./test/testdata/issues-SR1001.yaml')
@@ -22,12 +22,12 @@ describe('difftools', () => {
 
     it('gets issue detail', async () => {
       const yaml = await readYamlFile('./test/testdata/issues-SR1001.yaml')
-      const issue = await issues.getIssueDetail(yaml, 'fbf1af0675dc')
+      const issue = await issues.getIssueDetail(yaml, '4492bb31ea09')
 
       const data = issue.data as issues.DatabasePrivilege
-      expect(data.role).to.equal('acme_prod_all_tables_viewer')
-      expect(data.privilege).to.equal('usage')
-      expect(data.database).to.equal('acme')
+      expect(data.role).to.equal('ACME_PROD_ALL_TABLES_VIEWER')
+      expect(data.privilege).to.equal('USAGE')
+      expect(data.database).to.equal('ACME')
     })
   })
 
@@ -46,7 +46,7 @@ describe('difftools', () => {
 
       issues.ISSUE_HANDLERS.SR1001.fixYaml(yaml, issueList[0].data)
       issues.ISSUE_HANDLERS.SR1001.fixYaml(yaml, issueList[1].data)
-      expect(yaml.roleGrants.acme_prod_all_tables_viewer?.usage?.database).to.deep.equal(['acme', 'acme2'])
+      expect(yaml.roleGrants.ACME_PROD_ALL_TABLES_VIEWER?.USAGE?.DATABASE).to.deep.equal(['ACME', 'ACME2'])
 
       const newIssueList = issues.ISSUE_HANDLERS.SR1001.findIssues(yaml)
       expect(newIssueList).to.have.length(0)
@@ -68,7 +68,7 @@ describe('difftools', () => {
 
       issues.ISSUE_HANDLERS.SR1002.fixYaml(yaml, issueList[0].data)
       issues.ISSUE_HANDLERS.SR1002.fixYaml(yaml, issueList[1].data)
-      expect(yaml.roleGrants.acme_prod_all_tables_viewer?.usage?.schema).to.deep.equal(['acme.prod', 'acme.staging'])
+      expect(yaml.roleGrants.ACME_PROD_ALL_TABLES_VIEWER?.USAGE?.SCHEMA).to.deep.equal(['ACME.PROD', 'ACME.STAGING'])
 
       const newIssueList = issues.ISSUE_HANDLERS.SR1002.findIssues(yaml)
       expect(newIssueList).to.have.length(0)
@@ -89,13 +89,13 @@ describe('difftools', () => {
       expect(issueList).to.have.length(2)
 
       issues.ISSUE_HANDLERS.SR1005.fixYaml(yaml, issueList[0].data)
-      expect(yaml.roleGrants.sysadmin?.usage?.role).to.deep.equal(['foo'])
+      expect(yaml.roleGrants.SYSADMIN?.USAGE?.ROLE).to.deep.equal(['FOO'])
 
       const issueList2 = issues.ISSUE_HANDLERS.SR1005.findIssues(yaml)
       expect(issueList2).to.have.length(1)
 
       issues.ISSUE_HANDLERS.SR1005.fixYaml(yaml, issueList2[0].data)
-      expect(yaml.roleGrants.sysadmin?.usage?.role).to.deep.equal(['foo', 'bar'])
+      expect(yaml.roleGrants.SYSADMIN?.USAGE?.ROLE).to.deep.equal(['BAR', 'FOO'])
 
       const newIssueList = issues.ISSUE_HANDLERS.SR1005.findIssues(yaml)
       expect(newIssueList).to.have.length(0)

--- a/test/lib/snowflake.test.ts
+++ b/test/lib/snowflake.test.ts
@@ -1,8 +1,6 @@
-/* eslint-disable camelcase */
 import * as snowflake from '../../src/lib/snowflake'
-import {compressYaml} from '../../src/lib/snowflake-yaml-compress'
 import {expect} from 'chai'
-import {Yaml, PRIVILEGES, YamlRoles} from '../../src/lib/yaml'
+import {PRIVILEGES} from '../../src/lib/yaml'
 
 describe('snowflake', () => {
   it('sanitizePrivilege accepts good privileges', async () => {
@@ -70,65 +68,65 @@ describe('snowflake', () => {
   describe('query generation', () => {
     describe('basic grant', () => {
       it('generates grant', () => {
-        const cmd = snowflake.newGrantQuery({roleName: 'foo_usage', privilege: 'usage', objectType: 'schema', objectId: 'foo.bar'})
-        expect(cmd.query).to.deep.equal(['grant usage on schema identifier(?) to role identifier(?);', ['foo.bar', 'foo_usage']])
-        expect(cmd.entities).to.deep.equal([{type: 'role', id: 'foo_usage', action: 'create'}, {type: 'schema', id: 'foo.bar', action: 'create'}])
+        const cmd = snowflake.newGrantQuery({roleName: 'foo_usage', privilege: 'USAGE', objectType: 'SCHEMA', objectId: 'foo.bar'})
+        expect(cmd.query).to.deep.equal(['GRANT USAGE ON SCHEMA IDENTIFIER(?) TO ROLE IDENTIFIER(?);', ['foo.bar', 'foo_usage']])
+        expect(cmd.entities).to.deep.equal([{type: 'ROLE', id: 'foo_usage', action: 'create'}, {type: 'SCHEMA', id: 'foo.bar', action: 'create'}])
       })
       it('generates revoke', () => {
-        const cmd = snowflake.newRevokeQuery({roleName: 'foo_usage', privilege: 'usage', objectType: 'schema', objectId: 'foo.bar'})
-        expect(cmd.query).to.deep.equal(['revoke usage on schema identifier(?) from role identifier(?);', ['foo.bar', 'foo_usage']])
-        expect(cmd.entities).to.deep.equal([{type: 'role', id: 'foo_usage', action: 'delete'}, {type: 'schema', id: 'foo.bar', action: 'delete'}])
+        const cmd = snowflake.newRevokeQuery({roleName: 'foo_usage', privilege: 'USAGE', objectType: 'SCHEMA', objectId: 'foo.bar'})
+        expect(cmd.query).to.deep.equal(['REVOKE USAGE ON SCHEMA IDENTIFIER(?) FROM ROLE IDENTIFIER(?);', ['foo.bar', 'foo_usage']])
+        expect(cmd.entities).to.deep.equal([{type: 'ROLE', id: 'foo_usage', action: 'delete'}, {type: 'SCHEMA', id: 'foo.bar', action: 'delete'}])
       })
     })
 
     describe('hierarchichal role grant', () => {
       it('generates grant', () => {
-        const cmd = snowflake.newGrantQuery({roleName: 'foo_usage', privilege: 'usage', objectType: 'role', objectId: 'bar_usage'})
-        expect(cmd.query).to.deep.equal(['grant role identifier(?) to role identifier(?);', ['bar_usage', 'foo_usage']])
+        const cmd = snowflake.newGrantQuery({roleName: 'foo_usage', privilege: 'USAGE', objectType: 'ROLE', objectId: 'bar_usage'})
+        expect(cmd.query).to.deep.equal(['GRANT ROLE IDENTIFIER(?) TO ROLE IDENTIFIER(?);', ['bar_usage', 'foo_usage']])
       })
       it('generates revoke', () => {
-        const cmd = snowflake.newRevokeQuery({roleName: 'foo_usage', privilege: 'usage', objectType: 'role', objectId: 'bar_usage'})
-        expect(cmd.query).to.deep.equal(['revoke role identifier(?) from role identifier(?);', ['bar_usage', 'foo_usage']])
+        const cmd = snowflake.newRevokeQuery({roleName: 'foo_usage', privilege: 'USAGE', objectType: 'ROLE', objectId: 'bar_usage'})
+        expect(cmd.query).to.deep.equal(['REVOKE ROLE IDENTIFIER(?) FROM ROLE IDENTIFIER(?);', ['bar_usage', 'foo_usage']])
       })
     })
 
     describe('schema future grants', () => {
       it('generates grant', () => {
-        const cmd = snowflake.newGrantQuery({roleName: 'foo_bar_viewer', privilege: 'insert', objectType: 'table', objectId: 'foo.bar.<table>'})
-        expect(cmd.query).to.deep.equal(['grant insert on future tables in schema identifier(?) to role identifier(?);', ['foo.bar', 'foo_bar_viewer']])
+        const cmd = snowflake.newGrantQuery({roleName: 'foo_bar_viewer', privilege: 'INSERT', objectType: 'TABLE', objectId: 'foo.bar.<table>'})
+        expect(cmd.query).to.deep.equal(['GRANT INSERT ON FUTURE TABLES IN SCHEMA IDENTIFIER(?) TO ROLE IDENTIFIER(?);', ['foo.bar', 'foo_bar_viewer']])
       })
       it('generates revoke', () => {
-        const cmd = snowflake.newRevokeQuery({roleName: 'foo_bar_viewer', privilege: 'insert', objectType: 'table', objectId: 'foo.bar.<table>'})
-        expect(cmd.query).to.deep.equal(['revoke insert on future tables in schema identifier(?) from role identifier(?);', ['foo.bar', 'foo_bar_viewer']])
+        const cmd = snowflake.newRevokeQuery({roleName: 'foo_bar_viewer', privilege: 'INSERT', objectType: 'TABLE', objectId: 'foo.bar.<table>'})
+        expect(cmd.query).to.deep.equal(['REVOKE INSERT ON FUTURE TABLES IN SCHEMA IDENTIFIER(?) FROM ROLE IDENTIFIER(?);', ['foo.bar', 'foo_bar_viewer']])
       })
     })
 
     describe('database future grants on tables', () => {
       it('generates grant', () => {
-        const cmd = snowflake.newGrantQuery({roleName: 'foo_viewer', privilege: 'insert', objectType: 'table', objectId: 'foo.<table>'})
-        expect(cmd.query).to.deep.equal(['grant insert on future tables in database identifier(?) to role identifier(?);', ['foo', 'foo_viewer']])
+        const cmd = snowflake.newGrantQuery({roleName: 'foo_viewer', privilege: 'INSERT', objectType: 'TABLE', objectId: 'foo.<table>'})
+        expect(cmd.query).to.deep.equal(['GRANT INSERT ON FUTURE TABLES IN DATABASE IDENTIFIER(?) TO ROLE IDENTIFIER(?);', ['foo', 'foo_viewer']])
       })
       it('generates revoke', () => {
-        const cmd = snowflake.newRevokeQuery({roleName: 'foo_viewer', privilege: 'usage', objectType: 'schema', objectId: 'foo.<schema>'})
-        expect(cmd.query).to.deep.equal(['revoke usage on future schemas in database identifier(?) from role identifier(?);', ['foo', 'foo_viewer']])
+        const cmd = snowflake.newRevokeQuery({roleName: 'foo_viewer', privilege: 'USAGE', objectType: 'SCHEMA', objectId: 'foo.<schema>'})
+        expect(cmd.query).to.deep.equal(['REVOKE USAGE ON FUTURE SCHEMAS IN DATABASE IDENTIFIER(?) FROM ROLE IDENTIFIER(?);', ['foo', 'foo_viewer']])
       })
     })
 
     describe('all tables in schema / database', () => {
       it('generates grant on all in schema', () => {
-        const cmd = snowflake.newGrantQuery({roleName: 'foo_bar_viewer', privilege: 'select', objectType: 'table', objectId: 'foo.bar.*'})
-        expect(cmd.query).to.deep.equal(['grant select on all tables in schema identifier(?) to role identifier(?);', ['foo.bar', 'foo_bar_viewer']])
+        const cmd = snowflake.newGrantQuery({roleName: 'foo_bar_viewer', privilege: 'SELECT', objectType: 'TABLE', objectId: 'foo.bar.*'})
+        expect(cmd.query).to.deep.equal(['GRANT SELECT ON ALL TABLES IN SCHEMA IDENTIFIER(?) TO ROLE IDENTIFIER(?);', ['foo.bar', 'foo_bar_viewer']])
       })
       it('generates revoke on all in database', () => {
-        const cmd = snowflake.newRevokeQuery({roleName: 'foo_viewer', privilege: 'select', objectType: 'table', objectId: 'foo.*'})
-        expect(cmd.query).to.deep.equal(['revoke select on all tables in database identifier(?) from role identifier(?);', ['foo', 'foo_viewer']])
+        const cmd = snowflake.newRevokeQuery({roleName: 'foo_viewer', privilege: 'SELECT', objectType: 'TABLE', objectId: 'foo.*'})
+        expect(cmd.query).to.deep.equal(['REVOKE SELECT ON ALL TABLES IN DATABASE IDENTIFIER(?) FROM ROLE IDENTIFIER(?);', ['foo', 'foo_viewer']])
       })
     })
   })
 
   describe('normalizeRoleName', () => {
-    it('normalizes all caps role names', () => {
-      expect(snowflake.normalizeRoleName('MY_ROLE')).to.equal('my_role')
+    it('keeps all caps role names', () => {
+      expect(snowflake.normalizeRoleName('MY_ROLE')).to.equal('MY_ROLE')
     })
 
     it('preserves case and special characters in double-quotes', () => {
@@ -140,187 +138,4 @@ describe('snowflake', () => {
       expect(snowflake.normalizeRoleName(res)).to.equal('"My - Role"')
     })
   })
-
-  describe('compressYaml', () => {
-    const objects: snowflake.ShowObject[] = [
-      newObject('table1', 'db1', 'schema1', 'table'),
-      newObject('table2', 'db1', 'schema1', 'table'),
-      newObject('table3', 'db1', 'schema1', 'table'),
-      newObject('table1', 'db1', 'schema2', 'table'),
-      newObject('table1', 'db2', 'schema1', 'table'),
-      newObject('table2', 'db2', 'schema1', 'table'),
-      newObject('table1', 'db2', 'schema2', 'table'),
-      newObject('table2', 'db2', 'schema2', 'table'),
-      newObject('table1', 'db2', 'schema3', 'table'),
-      newObject('table2', 'db2', 'schema3', 'table'),
-    ]
-
-    it('replaces a list of tables with a wildcard', async () => {
-      const yaml = newYamlWithRole(
-        [
-          'db1.schema1.table1',
-          'db1.schema1.table2',
-          'db1.schema1.table3',
-        ],
-        ['db1'],
-        ['db1.schema1'],
-      )
-
-      const mockObjects = objects.filter(o => o.schema_name === 'schema1' && o.database_name === 'db1')
-
-      compressYaml(yaml, mockObjects)
-
-      expect(yaml.roleGrants.dataViewer?.select?.table).to.deep.equal(['db1.*'])
-      expect(yaml.roleGrants.dataViewer?.usage?.schema).to.deep.equal(['db1.*'])
-    })
-
-    it('replaces a list of tables with a wildcard, preserving future grants', async () => {
-      const yaml = newYamlWithRole(
-        [
-          'db1.schema1.<table>',
-          'db1.schema1.table1',
-          'db1.schema1.table2',
-          'db1.schema1.table3',
-        ],
-        ['db1'],
-        ['db1.schema1'],
-      )
-
-      const mockObjects = objects.filter(o => o.schema_name === 'schema1' && o.database_name === 'db1')
-
-      compressYaml(yaml, mockObjects)
-
-      expect(yaml.roleGrants.dataViewer?.select?.table).to.deep.equal(['db1.*', 'db1.schema1.<table>'])
-      expect(yaml.roleGrants.dataViewer?.usage?.schema).to.deep.equal(['db1.*'])
-    })
-
-    it('replaces a list of tables with a wildcard when there are more schemas', async () => {
-      const yaml = newYamlWithRole(
-        [
-          'db1.schema1.<table>',
-          'db1.schema1.table1',
-          'db1.schema1.table2',
-          'db1.schema1.table3',
-        ],
-        ['db1'],
-        ['db1.schema1'],
-      )
-
-      const mockObjects = objects.filter(o => o.database_name === 'db1')
-
-      compressYaml(yaml, mockObjects)
-
-      expect(yaml.roleGrants.dataViewer?.select?.table).to.deep.equal(['db1.schema1.*', 'db1.schema1.<table>'])
-      expect(yaml.roleGrants.dataViewer?.usage?.schema).to.deep.equal(['db1.schema1'])
-    })
-
-    it('doesnt compress if we dont have all tables in a schema', async () => {
-      const yaml = newYamlWithRole(
-        [
-          'db1.schema1.<table>',
-          'db1.schema1.table1',
-          'db1.schema1.table3',
-        ],
-        ['db1'],
-        ['db1.schema1', 'db1.schema2'],
-      )
-
-      const mockObjects = objects.filter(o => o.database_name === 'db1' && o.schema_name === 'schema1')
-
-      compressYaml(yaml, mockObjects)
-
-      expect(yaml.roleGrants.dataViewer?.select?.table).to.deep.equal(['db1.schema1.<table>', 'db1.schema1.table1', 'db1.schema1.table3'])
-      expect(yaml.roleGrants.dataViewer?.usage?.schema).to.deep.equal(['db1.*'])
-    })
-
-    it('compresses if we have all tables in all databases and schemas', async () => {
-      const yaml = newYamlWithRole(
-        [
-          'db1.<schema>',
-          'db1.schema1.table1',
-          'db1.schema1.table2',
-          'db1.schema1.table3',
-          'db1.schema2.table1',
-          'db2.schema1.table1',
-          'db2.schema1.table2',
-          'db2.schema2.table1',
-          'db2.schema2.table2',
-          'db2.schema3.table1',
-          'db2.schema3.table2',
-        ],
-        ['db1', 'db2'],
-        ['db1.schema1', 'db1.schema2', 'db2.schema1', 'db2.schema2', 'db2.schema3'],
-      )
-
-      const mockObjects = objects
-
-      compressYaml(yaml, mockObjects)
-
-      expect(yaml.roleGrants.dataViewer?.select?.table).to.deep.equal(['db1.*', 'db1.<schema>', 'db2.*'])
-      expect(yaml.roleGrants.dataViewer?.usage?.schema).to.deep.equal(['db1.*', 'db2.*'])
-    })
-
-    it('partially compresses if we have all tables in all databases and some schemas', async () => {
-      const yaml = newYamlWithRole(
-        [
-          'db1.<schema>',
-          'db1.schema1.table1',
-          'db1.schema1.table2',
-          'db1.schema1.table3',
-          'db1.schema2.table1',
-          'db2.schema1.table1',
-          'db2.schema1.table2',
-          'db2.schema2.table1',
-          'db2.schema2.table2',
-        ],
-        ['db1', 'db2'],
-        ['db1.schema1', 'db1.schema2', 'db2.schema1', 'db2.schema2'],
-      )
-
-      const mockObjects = objects
-
-      compressYaml(yaml, mockObjects)
-
-      expect(yaml.roleGrants.dataViewer?.select?.table).to.deep.equal(['db1.*', 'db1.<schema>', 'db2.schema1.*', 'db2.schema2.*'])
-      expect(yaml.roleGrants.dataViewer?.usage?.schema).to.deep.equal(['db1.*', 'db2.schema1', 'db2.schema2'])
-    })
-  })
 })
-
-function newYaml(roleGrants: YamlRoles): Yaml {
-  return {
-    roleGrants,
-    warehouses: {},
-    userGrants: {},
-    spyglass: {
-      accountId: 'account-123',
-      platform: 'snowflake',
-      version: 1,
-      lastSyncedMs: Date.now(),
-    },
-    roles: {},
-  }
-}
-
-function newYamlWithRole(table: string[], database: string[], schema: string[]): Yaml {
-  return newYaml({
-    dataViewer: {
-      select: {
-        table,
-      },
-      usage: {
-        database,
-        schema,
-      },
-    },
-  })
-}
-
-function newObject(name: string, database: string, schema: string, kind: string): snowflake.ShowObject {
-  return {
-    name,
-    kind,
-    database_name: database,
-    schema_name: schema,
-  }
-}

--- a/test/lib/spyglass.test.ts
+++ b/test/lib/spyglass.test.ts
@@ -24,40 +24,40 @@ describe('SnowflakeSpyglass', () => {
       const yaml = await spyg.import({accountId: 'account-123', onStart: noopFunc, onProgress: noopFunc})
 
       expect(yaml.roleGrants).to.deep.equal({
-        acme_prod_call_center_reader: {
-          select: {
-            view: ['acme.prod.call_center'],
+        ACME_PROD_CALL_CENTER_READER: {
+          SELECT: {
+            VIEW: ['ACME.PROD.CALL_CENTER'],
           },
-          usage: {
-            database: ['acme'],
-            schema: ['acme.prod'],
-          },
-        },
-        acme_prod_all_tables_viewer: {
-          select: {
-            table: ['acme.prod.<future>'],
+          USAGE: {
+            DATABASE: ['ACME'],
+            SCHEMA: ['ACME.PROD'],
           },
         },
-        customer_support: {
-          usage: {
-            role: ['acme_prod_call_center_reader'],
+        ACME_PROD_ALL_TABLES_VIEWER: {
+          SELECT: {
+            TABLE: ['ACME.PROD.<FUTURE>'],
+          },
+        },
+        CUSTOMER_SUPPORT: {
+          USAGE: {
+            ROLE: ['ACME_PROD_CALL_CENTER_READER'],
           },
         },
       })
 
       expect(yaml.userGrants).to.deep.equal({
-        chuck_support: {
-          roles: ['customer_support'],
+        CHUCK_SUPPORT: {
+          roles: ['CUSTOMER_SUPPORT'],
         },
-        alice_admin: {
-          roles: ['"Snowflake - Admins"', 'acme_prod_all_tables_viewer'],
+        ALICE_ADMIN: {
+          roles: ['"Snowflake - Admins"', 'ACME_PROD_ALL_TABLES_VIEWER'],
         },
       })
 
       expect(yaml.roles).to.deep.equal({
-        acme_prod_all_tables_viewer: {},
-        acme_prod_call_center_reader: {},
-        customer_support: {},
+        ACME_PROD_ALL_TABLES_VIEWER: {},
+        ACME_PROD_CALL_CENTER_READER: {},
+        CUSTOMER_SUPPORT: {},
         '"Snowflake - Admins"': {},
       })
 
@@ -82,26 +82,26 @@ describe('SnowflakeSpyglass', () => {
       expect(updatedYaml.spyglass.lastSyncedMs).to.not.equal(oldSpyglass.lastSyncedMs)
 
       expect(updatedYaml.roleGrants).to.deep.equal({
-        acme_prod_all_tables_viewer: {
-          select: {
-            table: ['acme.prod.<future>'],
+        ACME_PROD_ALL_TABLES_VIEWER: {
+          SELECT: {
+            TABLE: ['ACME.PROD.<FUTURE>'],
           },
         },
       })
 
       expect(updatedYaml.userGrants).to.deep.equal({
-        alice_admin: {
-          roles: ['acme_prod_all_tables_viewer'],
+        ALICE_ADMIN: {
+          roles: ['ACME_PROD_ALL_TABLES_VIEWER'],
         },
       })
 
       expect(updatedYaml.roles).to.deep.equal({
-        acme_prod_all_tables_viewer: {},
+        ACME_PROD_ALL_TABLES_VIEWER: {},
       })
     })
   })
 
-  const mockIssues: issues.Issue[] = [issues.newSR1001({role: 'acme_user', database: 'acme'})]
+  const mockIssues: issues.Issue[] = [issues.newSR1001({role: 'ACME_USER', database: 'ACME'})]
   mockIssues[0].id = 'issue-123'
   describe('verify', () => {
     test
@@ -115,9 +115,9 @@ describe('SnowflakeSpyglass', () => {
     test
     .it('returns details when an arg is passed', async () => {
       const yaml = await readYamlFile('test/testdata/issues-SR1001.yaml')
-      const issue = (await spyg.verify(yaml, 'fbf1af0675dc')) as issues.IssueDetail
+      const issue = (await spyg.verify(yaml, '4492bb31ea09')) as issues.IssueDetail
 
-      expect(issue.yamlDiff.added.roleGrants.acme_prod_all_tables_viewer?.usage?.database).to.deep.equal(['acme'])
+      expect(issue.yamlDiff.added.roleGrants.ACME_PROD_ALL_TABLES_VIEWER?.USAGE?.DATABASE).to.deep.equal(['ACME'])
       expect(issue.yamlDiff.deleted).to.be.empty
       expect(issue.yamlDiff.updated).to.be.empty
     })
@@ -137,53 +137,53 @@ describe('SnowflakeSpyglass', () => {
     it('finds databases that do and don\'t exist', () => {
       const proposedRoles: YamlRoleDefinitions = {}
       const objects: snowflake.ShowObject[] = [
-        {name: 'order_history', database_name: 'acme', schema_name: 'prod', kind: 'table'},
+        {name: 'ORDER_HISTORY', database_name: 'ACME', schema_name: 'PROD', kind: 'TABLE'},
       ]
       const users: snowflake.ShowUser[] = []
       const sqlCommands: SqlCommand[] = [
-        newSqlCommandWithEntities({type: 'database', id: 'acme', action: 'create'}),
-        newSqlCommandWithEntities({type: 'database', id: 'doesnt_exist', action: 'create'}),
+        newSqlCommandWithEntities({type: 'DATABASE', id: 'ACME', action: 'create'}),
+        newSqlCommandWithEntities({type: 'DATABASE', id: 'DOESNT_EXIST', action: 'create'}),
       ]
 
       const missingEntities = spyglass._findNotExistingEntities(proposedRoles, objects, users, sqlCommands)
       expect(missingEntities).to.have.length(1)
-      expect(missingEntities[0]).to.deep.equal({type: 'database', id: 'doesnt_exist', action: 'create'})
+      expect(missingEntities[0]).to.deep.equal({type: 'DATABASE', id: 'DOESNT_EXIST', action: 'create'})
     })
 
     it('finds schemas that do and don\'t exist', () => {
       const proposedRoles: YamlRoleDefinitions = {}
       const objects: snowflake.ShowObject[] = [
-        {name: 'order_history', database_name: 'acme', schema_name: 'prod', kind: 'table'},
+        {name: 'ORDER_HISTORY', database_name: 'ACME', schema_name: 'PROD', kind: 'TABLE'},
       ]
       const users: snowflake.ShowUser[] = []
       const sqlCommands: SqlCommand[] = [
-        newSqlCommandWithEntities({type: 'database', id: 'acme', action: 'create'}),
-        newSqlCommandWithEntities({type: 'schema', id: 'acme.prod', action: 'create'}),
-        newSqlCommandWithEntities({type: 'schema', id: 'acme.doesnt_exist', action: 'create'}),
+        newSqlCommandWithEntities({type: 'DATABASE', id: 'ACME', action: 'create'}),
+        newSqlCommandWithEntities({type: 'SCHEMA', id: 'ACME.PROD', action: 'create'}),
+        newSqlCommandWithEntities({type: 'SCHEMA', id: 'ACME.DOESNT_EXIST', action: 'create'}),
       ]
 
       const missingEntities = spyglass._findNotExistingEntities(proposedRoles, objects, users, sqlCommands)
       expect(missingEntities).to.have.length(1)
-      expect(missingEntities[0]).to.deep.equal({type: 'schema', id: 'acme.doesnt_exist', action: 'create'})
+      expect(missingEntities[0]).to.deep.equal({type: 'SCHEMA', id: 'ACME.DOESNT_EXIST', action: 'create'})
     })
 
     it('finds tables that do and don\'t exist', () => {
       const proposedRoles: YamlRoleDefinitions = {}
       const objects: snowflake.ShowObject[] = [
-        {name: 'order_history', database_name: 'acme', schema_name: 'prod', kind: 'table'},
-        {name: 'payment_history', database_name: 'acme', schema_name: 'prod', kind: 'table'},
+        {name: 'ORDER_HISTORY', database_name: 'ACME', schema_name: 'PROD', kind: 'TABLE'},
+        {name: 'PAYMENT_HISTORY', database_name: 'ACME', schema_name: 'PROD', kind: 'TABLE'},
       ]
       const users: snowflake.ShowUser[] = []
       const sqlCommands: SqlCommand[] = [
-        newSqlCommandWithEntities({type: 'database', id: 'acme', action: 'create'}),
-        newSqlCommandWithEntities({type: 'schema', id: 'acme.prod', action: 'create'}),
-        newSqlCommandWithEntities({type: 'table', id: 'acme.prod.order_history', action: 'create'}),
-        newSqlCommandWithEntities({type: 'table', id: 'acme.prod.doesnt_exist', action: 'create'}),
+        newSqlCommandWithEntities({type: 'DATABASE', id: 'ACME', action: 'create'}),
+        newSqlCommandWithEntities({type: 'SCHEMA', id: 'ACME.PROD', action: 'create'}),
+        newSqlCommandWithEntities({type: 'TABLE', id: 'ACME.PROD.ORDER_HISTORY', action: 'create'}),
+        newSqlCommandWithEntities({type: 'TABLE', id: 'ACME.PROD.DOESNT_EXIST', action: 'create'}),
       ]
 
       const missingEntities = spyglass._findNotExistingEntities(proposedRoles, objects, users, sqlCommands)
       expect(missingEntities).to.have.length(1)
-      expect(missingEntities[0]).to.deep.equal({type: 'table', id: 'acme.prod.doesnt_exist', action: 'create'})
+      expect(missingEntities[0]).to.deep.equal({type: 'TABLE', id: 'ACME.PROD.DOESNT_EXIST', action: 'create'})
     })
 
     it('skips objects that don\'t exist if permissions are being revoked', () => {

--- a/test/testdata/issues-SR1001.yaml
+++ b/test/testdata/issues-SR1001.yaml
@@ -1,25 +1,25 @@
 roleGrants:
-  acme_prod_all_tables_viewer:
-    select:
-      table:
-        - acme.prod.<table>
-      view:
-        - acme.prod.<view>
-        - acme.prod.call_center
-        - acme.prod.catalog_page
-        - acme.prod.catalog_returns
-        - acme.prod.catalog_sales
-        - acme2.prod.catalog_sales
-    usage:
-      schema:
-        - acme.prod
-        - acme2.prod
+  ACME_PROD_ALL_TABLES_VIEWER:
+    SELECT:
+      TABLE:
+        - ACME.PROD.<FUTURE>
+      VIEW:
+        - ACME.PROD.<FUTURE>
+        - ACME.PROD.CALL_CENTER
+        - ACME.PROD.CATALOG_PAGE
+        - ACME.PROD.CATALOG_RETURNS
+        - ACME.PROD.CATALOG_SALES
+        - ACME2.PROD.CATALOG_SALES
+    USAGE:
+      SCHEMA:
+        - ACME.PROD
+        - ACME2.PROD
 spyglass:
   accountId: account-123
   lastSyncedMs: 1678883775793
   platform: snowflake
   version: 1
 userGrants:
-  charles_stevens:
+  CHARLES_STEVENS:
     roles:
-      - acme_prod_all_tables_viewer
+      - ACME_PROD_ALL_TABLES_VIEWER

--- a/test/testdata/issues-SR1002.yaml
+++ b/test/testdata/issues-SR1002.yaml
@@ -1,24 +1,24 @@
 roleGrants:
-  acme_prod_all_tables_viewer:
-    select:
-      table:
-        - acme.prod.<table>
-      view:
-        - acme.prod.<view>
-        - acme.prod.call_center
-        - acme.prod.catalog_page
-        - acme.prod.catalog_returns
-        - acme.prod.catalog_sales
-        - acme.staging.catalog_sales
-    usage:
-      database:
-        - acme
+  ACME_PROD_ALL_TABLES_VIEWER:
+    SELECT:
+      TABLE:
+        - ACME.PROD.<FUTURE>
+      VIEW:
+        - ACME.PROD.<FUTURE>
+        - ACME.PROD.CALL_CENTER
+        - ACME.PROD.CATALOG_PAGE
+        - ACME.PROD.CATALOG_RETURNS
+        - ACME.PROD.CATALOG_SALES
+        - ACME.STAGING.CATALOG_SALES
+    USAGE:
+      DATABASE:
+        - ACME
 spyglass:
   accountId: account-123
   lastSyncedMs: 1678883775793
   platform: snowflake
   version: 1
 userGrants:
-  charles_stevens:
+  CHARLES_STEVENS:
     roles:
-      - acme_prod_all_tables_viewer
+      - ACME_PROD_ALL_TABLES_VIEWER

--- a/test/testdata/issues-SR1005.yaml
+++ b/test/testdata/issues-SR1005.yaml
@@ -1,9 +1,9 @@
 roles:
-  foo: {}
-  bar: {}
-  sysadmin: {}
+  FOO: {}
+  BAR: {}
+  SYSADMIN: {}
 roleGrants:
-  foo: {}
+  FOO: {}
 spyglass:
   accountId: account-123
   lastSyncedMs: 1678883775793

--- a/test/testdata/spyglass-import-snowflake-stub-basic.json
+++ b/test/testdata/spyglass-import-snowflake-stub-basic.json
@@ -2,95 +2,95 @@
   "roleGrants": [
     {
       "created_on": "2023-02-26 12:40:02.747 -0800",
-      "privilege": "select",
-      "granted_on": "view",
-      "name": "acme.prod.call_center",
-      "granted_to": "role",
-      "grantee_name": "acme_prod_call_center_reader",
+      "privilege": "SELECT",
+      "granted_on": "VIEW",
+      "name": "ACME.PROD.CALL_CENTER",
+      "granted_to": "ROLE",
+      "grantee_name": "ACME_PROD_CALL_CENTER_READER",
       "grant_option": "false",
-      "granted_by": "accountadmin"
+      "granted_by": "ACCOUNTADMIN"
     },
     {
       "created_on": "2023-02-26 12:40:02.747 -0800",
-      "privilege": "usage",
-      "granted_on": "database",
-      "name": "acme",
-      "granted_to": "role",
-      "grantee_name": "acme_prod_call_center_reader",
+      "privilege": "USAGE",
+      "granted_on": "DATABASE",
+      "name": "ACME",
+      "granted_to": "ROLE",
+      "grantee_name": "ACME_PROD_CALL_CENTER_READER",
       "grant_option": "false",
-      "granted_by": "accountadmin"
+      "granted_by": "ACCOUNTADMIN"
     },
     {
       "created_on": "2023-02-26 12:40:02.747 -0800",
-      "privilege": "usage",
-      "granted_on": "schema",
-      "name": "acme.prod",
-      "granted_to": "role",
-      "grantee_name": "acme_prod_call_center_reader",
+      "privilege": "USAGE",
+      "granted_on": "SCHEMA",
+      "name": "ACME.PROD",
+      "granted_to": "ROLE",
+      "grantee_name": "ACME_PROD_CALL_CENTER_READER",
       "grant_option": "false",
-      "granted_by": "accountadmin"
+      "granted_by": "ACCOUNTADMIN"
     },
     {
       "created_on": "2023-02-26 12:40:02.747 -0800",
-      "privilege": "usage",
-      "granted_on": "role",
-      "name": "acme_prod_call_center_reader",
-      "granted_to": "role",
-      "grantee_name": "customer_support",
+      "privilege": "USAGE",
+      "granted_on": "ROLE",
+      "name": "ACME_PROD_CALL_CENTER_READER",
+      "granted_to": "ROLE",
+      "grantee_name": "CUSTOMER_SUPPORT",
       "grant_option": "false",
-      "granted_by": "accountadmin"
+      "granted_by": "ACCOUNTADMIN"
     }
   ],
   "futureRoleGrants": [
     {
       "created_on": "2023-03-10 06:29:45.905 -0800",
-      "privilege": "select",
-      "grant_on": "table",
-      "name": "acme.prod.<table>",
-      "grant_to": "role",
-      "grantee_name": "acme_prod_all_tables_viewer",
+      "privilege": "SELECT",
+      "grant_on": "TABLE",
+      "name": "ACME.PROD.<TABLE>",
+      "grant_to": "ROLE",
+      "grantee_name": "ACME_PROD_ALL_TABLES_VIEWER",
       "grant_option": "false"
     }
   ],
   "roleGrantsOf": [
     {
       "created_on": "2023-02-26 12:49:23.439 -0800",
-      "role": "acme_prod_call_center_reader",
-      "granted_to": "role",
-      "grantee_name": "customer_support",
-      "granted_by": "accountadmin"
+      "role": "ACME_PROD_CALL_CENTER_READER",
+      "granted_to": "ROLE",
+      "grantee_name": "CUSTOMER_SUPPORT",
+      "granted_by": "ACCOUNTADMIN"
     },
     {
       "created_on": "2023-02-26 12:49:41.301 -0800",
-      "role": "customer_support",
-      "granted_to": "user",
-      "grantee_name": "chuck_support",
-      "granted_by": "accountadmin"
+      "role": "CUSTOMER_SUPPORT",
+      "granted_to": "USER",
+      "grantee_name": "CHUCK_SUPPORT",
+      "granted_by": "ACCOUNTADMIN"
     },
     {
       "created_on": "2023-02-26 12:49:41.301 -0800",
-      "role": "acme_prod_all_tables_viewer",
-      "granted_to": "user",
-      "grantee_name": "alice_admin",
-      "granted_by": "accountadmin"
+      "role": "ACME_PROD_ALL_TABLES_VIEWER",
+      "granted_to": "USER",
+      "grantee_name": "ALICE_ADMIN",
+      "granted_by": "ACCOUNTADMIN"
     },
     {
       "created_on": "2023-02-26 12:49:41.301 -0800",
       "role": "\"Snowflake - Admins\"",
-      "granted_to": "user",
-      "grantee_name": "alice_admin",
-      "granted_by": "accountadmin"
+      "granted_to": "USER",
+      "grantee_name": "ALICE_ADMIN",
+      "granted_by": "ACCOUNTADMIN"
     }
   ],
   "roles": [
     {
-      "name": "acme_prod_call_center_reader"
+      "name": "ACME_PROD_CALL_CENTER_READER"
     },
     {
-      "name": "customer_support"
+      "name": "CUSTOMER_SUPPORT"
     },
     {
-      "name": "acme_prod_all_tables_viewer"
+      "name": "ACME_PROD_ALL_TABLES_VIEWER"
     },
     {
       "name": "\"Snowflake - Admins\""

--- a/test/testdata/spyglass-sync-snowflake-stub-basic.json
+++ b/test/testdata/spyglass-sync-snowflake-stub-basic.json
@@ -3,26 +3,26 @@
   "futureRoleGrants": [
     {
       "created_on": "2023-03-10 06:29:45.905 -0800",
-      "privilege": "select",
-      "grant_on": "table",
-      "name": "acme.prod.<table>",
-      "grant_to": "role",
-      "grantee_name": "acme_prod_all_tables_viewer",
+      "privilege": "SELECT",
+      "grant_on": "TABLE",
+      "name": "ACME.PROD.<TABLE>",
+      "grant_to": "ROLE",
+      "grantee_name": "ACME_PROD_ALL_TABLES_VIEWER",
       "grant_option": "false"
     }
   ],
   "roleGrantsOf": [
     {
       "created_on": "2023-02-26 12:49:41.301 -0800",
-      "role": "acme_prod_all_tables_viewer",
-      "granted_to": "user",
-      "grantee_name": "alice_admin",
-      "granted_by": "accountadmin"
+      "role": "ACME_PROD_ALL_TABLES_VIEWER",
+      "granted_to": "USER",
+      "grantee_name": "ALICE_ADMIN",
+      "granted_by": "ACCOUNTADMIN"
     }
   ],
   "roles": [
     {
-      "name": "acme_prod_all_tables_viewer"
+      "name": "ACME_PROD_ALL_TABLES_VIEWER"
     }
   ],
   "databaseRoles": [],


### PR DESCRIPTION
This is a significant breaking change that impacts `sync` and `import` primarily.

Previously, when importing/syncing Snowflake privileges, Spyglass CLI would coerce all names into lowercase.

After this change, Spyglass CLI makes no effort to normalize or mutate the names of Snowflake users, databases, schemas, roles, privileges, and objects.